### PR TITLE
subscriber_data extended for mw.mail_subscribe event

### DIFF
--- a/functions/subscriber_functions.php
+++ b/functions/subscriber_functions.php
@@ -25,6 +25,11 @@ function newsletter_subscribe($params)
     	$name = Input::get('name');
     }
 
+    $last_name = '';
+   	if (!empty(Input::get('last_name'))) {
+   		$last_name = Input::get('last_name');
+    }
+
     $adm = mw()->user_manager->is_admin();
     if (defined('MW_API_CALL')) {
         $validate_token = mw()->user_manager->csrf_validate($params);
@@ -150,6 +155,7 @@ function newsletter_subscribe($params)
     $subscriber_data = [
     	'email' => Input::get('email'),
     	'name' => $name,
+    	'last_name' => $last_name,
     	'list_id' => $list_id,
     	'confirmation_code' => $confirmation_code
     ];
@@ -229,6 +235,9 @@ function newsletter_save_subscriber($data)
     $subscriber_data['rel_type'] = 'newsletter_subscribers';
     $subscriber_data['rel_id'] = $save_id;
     $subscriber_data['option_group'] = 'newsletter';
+    if(isset($data['email'])) $subscriber_data['email'] = $data['email'];
+    if(isset($data['name'])) $subscriber_data['name'] = $data['name'];
+    if(isset($data['last_name'])) $subscriber_data['last_name'] = $data['last_name'];
 
     event_trigger('mw.mail_subscribe', $subscriber_data);
 


### PR DESCRIPTION
Can you extend the subscriber_data array with email and name(s) for use with the mw.mail_subscribe event please.